### PR TITLE
Exclude extra files when downloading from Asset Library

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,9 @@
-# Normalize EOL for all files that Git considers text files.
+# Normalize line endings for all files that Git considers text files.
 * text=auto eol=lf
+
+# Only include the addons folder when downloading from the Asset Library.
+/**                   export-ignore
+/addons               !export-ignore
+/addons/**            !export-ignore
+/script_templates     !export-ignore
+/script_templates/**  !export-ignore

--- a/addons/finite_state_machine/license
+++ b/addons/finite_state_machine/license
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 HexagonNico
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/addons/finite_state_machine/readme.md
+++ b/addons/finite_state_machine/readme.md
@@ -1,0 +1,82 @@
+
+# Finite State Machine plugin
+
+A GDScript implementation of the finite state machine pattern.
+
+Adds node types for finite state machines and states.
+
+## Installing the plugin in your project
+
+The procedure is the same as other Godot plugins.
+See the [Godot docs](https://docs.godotengine.org/en/stable/tutorials/plugins/editor/installing_plugins.html) for a full explanation.
+
+1. Click the **AssetLib** tab at the top of the editor and look for Finite State Machine.
+
+2. Download the plugin and install the contents of the `addons` and the `script_templates` folders into your project's directory. You don't need the contents of the `example` folder.
+
+3. Go to `Project -> Project Settings... -> Plugins` and enable the plugin by checking "Enable".
+
+It is also possible to install the plugin manually by downloading the zip archive from the [Releases section](https://github.com/HexagonNico/GodotPlugin-FiniteStateMachine/releases).
+
+## Plugin contents
+
+The plugin contains two [script classes](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html#doc-gdscript-basics-class-name): `FiniteStateMachine` and `StateMachineState`.
+Both can be added to your scenes as nodes through the "Create New Node" menu.
+
+![Create node](/example/readme/create_node.png)
+
+The **FiniteStateMachine** node can be added as a child of your character's node and will handle the state machine's logic.
+
+The **StateMachineState** class is an abstract class. You can extend this script to create your states.
+
+## Creating a state machine
+
+Open the "Create New Node" menu and search for "FiniteStateMachine". Add this node in your character's scene.
+
+![State machine inspector](/example/readme/state_machine_inspector.png)
+
+A state machine by itself does nothing, you need to create a script for a state.
+From the "Create script" menu, create a script that inherits from `StateMachineState`.
+
+![Create script](/example/readme/create_script.png)
+
+The script template downloaded with the plugin will generate some function stubs.
+You can now implement these functions to create a state.
+
+```
+class_name MyState
+extends StateMachineState
+
+
+# Called when the state machine enters this state.
+func on_enter() -> void:
+	pass
+
+
+# Called every frame when this state is active.
+func on_process(delta: float) -> void:
+	pass
+
+
+# Called every physics frame when this state is active.
+func on_physics_process(delta: float) -> void:
+	pass
+
+
+# Called when there is an input event while this state is active.
+func on_input(event: InputEvent) -> void:
+	pass
+
+
+# Called when the state machine exits this state.
+func on_exit() -> void:
+	pass
+```
+
+Once a state is created, you can add it as a child of the FiniteStateMachine node.
+Assign a state to the state machine from the inspector to set that as the initial state.
+
+You can now change between states from your scripts by setting `current_state` or using the `change_state` function.
+See the comments in the scripts for a full explanation.
+
+![State machine scene](/example/readme/state_machine_scene.png)


### PR DESCRIPTION
Made some adjustments to exclude files that are not in addons and script_templates folders when downloading from the Asset Library (recommended [here](https://docs.godotengine.org/en/stable/community/asset_library/submitting_to_assetlib.html#recommendations)) as well as including the license and readme in the addons folder (also recommended).