### PR TITLE
Leverage `Node.PROCESS_MODE_*` in order to prevent `on_process`, `on_physics_process`, etc. function calls from the parent state machine

### DIFF
--- a/addons/finite_state_machine/scripts/finite_state_machine.gd
+++ b/addons/finite_state_machine/scripts/finite_state_machine.gd
@@ -32,7 +32,11 @@ var _previous_state: StateMachineState = null
 # '_enter_tree' if the state machine node's '_ready' function has not been called yet to ensure
 # that the state node's '_ready' function is called before 'on_enter'.
 func _enter_tree() -> void:
+	for state in get_children():
+		state.process_mode = Node.PROCESS_MODE_DISABLED
+	
 	if is_node_ready() and is_instance_valid(current_state):
+		current_state.process_mode = Node.PROCESS_MODE_INHERIT
 		current_state.on_enter()
 		current_state.state_entered.emit()
 
@@ -42,7 +46,11 @@ func _enter_tree() -> void:
 # called after its '_ready' function, since the setter function of exported variables is called
 # before '_ready'.
 func _ready() -> void:
+	for state in get_children():
+		state.process_mode = Node.PROCESS_MODE_DISABLED
+	
 	if is_instance_valid(current_state):
+		current_state.process_mode = Node.PROCESS_MODE_INHERIT
 		current_state.on_enter()
 		current_state.state_entered.emit()
 
@@ -53,6 +61,7 @@ func _exit_tree() -> void:
 	if is_instance_valid(current_state):
 		current_state.on_exit()
 		current_state.state_exited.emit()
+		current_state.process_mode = Node.PROCESS_MODE_DISABLED
 
 
 # Changes state to the one at the given path relative to the state machine node. This function can
@@ -95,12 +104,14 @@ func set_current_state(next_state: StateMachineState) -> void:
 	if is_inside_tree() and is_instance_valid(current_state):
 		current_state.on_exit()
 		current_state.state_exited.emit()
+		current_state.process_mode = Node.PROCESS_MODE_DISABLED
 	_previous_state = current_state
 	current_state = next_state
 	# Enter the new state
 	if is_instance_valid(current_state):
 		current_state.state_machine = self
 		if is_inside_tree():
+			current_state.process_mode = Node.PROCESS_MODE_INHERIT
 			state_changed.emit(current_state)
 			current_state.on_enter()
 			current_state.state_entered.emit()

--- a/addons/finite_state_machine/scripts/finite_state_machine.gd
+++ b/addons/finite_state_machine/scripts/finite_state_machine.gd
@@ -47,27 +47,6 @@ func _ready() -> void:
 		current_state.state_entered.emit()
 
 
-# Called every frame.
-# Calls the 'on_process' function on the current state.
-func _process(delta: float) -> void:
-	if is_instance_valid(current_state):
-		current_state.on_process(delta)
-
-
-# Called every physics frame.
-# Calls the 'on_physics_process' function on the current state.
-func _physics_process(delta: float) -> void:
-	if is_instance_valid(current_state):
-		current_state.on_physics_process(delta)
-
-
-# Called when there is an input event that hasn't been consumed by the gui.
-# Calls the 'on_input' function on the current state.
-func _unhandled_input(event: InputEvent) -> void:
-	if is_instance_valid(current_state):
-		current_state.on_input(event)
-
-
 # Called when the node exits the scene tree.
 # Calls the 'on_exit' function on the current state.
 func _exit_tree() -> void:

--- a/addons/finite_state_machine/scripts/state_machine_state.gd
+++ b/addons/finite_state_machine/scripts/state_machine_state.gd
@@ -23,21 +23,6 @@ func on_enter() -> void:
 	pass
 
 
-# Called every frame when this state is active.
-func on_process(_delta: float) -> void:
-	pass
-
-
-# Called every physics frame when this state is active.
-func on_physics_process(_delta: float) -> void:
-	pass
-
-
-# Called when there is an input event while this state is active.
-func on_input(_event: InputEvent) -> void:
-	pass
-
-
 # Called when the state machine exits this state.
 func on_exit() -> void:
 	pass

--- a/example/scripts/base_state.gd
+++ b/example/scripts/base_state.gd
@@ -6,7 +6,7 @@ extends CharacterState
 
 
 # Called every frame when this state is active.
-func on_process(_delta: float) -> void:
+func _process(_delta: float) -> void:
 	# Basic movement
 	var direction := Input.get_axis("ui_left", "ui_right")
 	if direction:
@@ -24,5 +24,5 @@ func on_process(_delta: float) -> void:
 
 
 # Called every physics frame when this state is active.
-func on_physics_process(_delta: float) -> void:
+func _physics_process(_delta: float) -> void:
 	character.move_and_slide()

--- a/example/scripts/jump_state.gd
+++ b/example/scripts/jump_state.gd
@@ -13,7 +13,7 @@ func on_enter() -> void:
 
 
 # Called every frame when this state is active.
-func on_process(delta: float) -> void:
+func _process(delta: float) -> void:
 	if character.is_on_floor():
 		change_state("Walk")
 		return
@@ -25,5 +25,5 @@ func on_process(delta: float) -> void:
 
 
 # Called every physics frame when this state is active.
-func on_physics_process(_delta: float) -> void:
+func _physics_process(_delta: float) -> void:
 	character.move_and_slide()

--- a/example/scripts/run_state.gd
+++ b/example/scripts/run_state.gd
@@ -3,6 +3,6 @@ extends BaseState
 
 
 # Called when there is an input event while this state is active.
-func on_input(event: InputEvent) -> void:
+func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_released("ui_cancel"):
 		change_state("Walk")

--- a/example/scripts/walk_state.gd
+++ b/example/scripts/walk_state.gd
@@ -3,6 +3,6 @@ extends BaseState
 
 
 # Called when there is an input event while this state is active.
-func on_input(event: InputEvent) -> void:
+func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_cancel"):
 		change_state("Run")

--- a/readme.md
+++ b/readme.md
@@ -54,17 +54,22 @@ func on_enter() -> void:
 
 
 # Called every frame when this state is active.
-func on_process(delta: float) -> void:
+func _process(delta: float) -> void:
 	pass
 
 
 # Called every physics frame when this state is active.
-func on_physics_process(delta: float) -> void:
+func _physics_process(delta: float) -> void:
 	pass
 
 
 # Called when there is an input event while this state is active.
-func on_input(event: InputEvent) -> void:
+func _input(event: InputEvent) -> void:
+	pass
+
+
+# Called when there is an input event (unhandled) while this state is active.
+func _unhandled_input(event: InputEvent) -> void:
 	pass
 
 


### PR DESCRIPTION
## Why should this PR be merged?

Optimization, performance, integration with the engine built-in virtual functions and ease of usage.

From the docs (https://docs.godotengine.org/en/stable/tutorials/scripting/pausing_games.html):

> The `_process`, `_physics_process`, `_input`, and `_input_event` functions will not be called. However signals still work and cause their connected function to run, even if that function's script is attached to a node that is not currently being processed.

This means we can pause nodes using `Node.PROCESS_MODE_DISABLED` and expect `_process`, `_physics_process`, etc. not to be called and thus we can remove `on_process`, `on_physics_process`, etc. (since we can use those built-in virtual functions directly).

Besides that, this PR allows the use of other virtual functions like `_unhandled_input` without needing to add an extra layer of complexity (`current_state.on_unhandled_input()`).

People are more used to override `_process` for logic that needs to be called every frame and having `on_process` just adds another way to do the same thing, while one of them (`_process`) isn't limited to the time slice that particular state is active. The same for `_physics_process` and `_input`.